### PR TITLE
Force minimum width on data column

### DIFF
--- a/templates/index.template.html
+++ b/templates/index.template.html
@@ -12,6 +12,7 @@
         }
         .data {
             font-family: "Droid Sans Mono", monospace;
+            min-width: 30em;
         }
         .header_endian {
             background-color: greenyellow;


### PR DESCRIPTION
When a big chunk of decoded metadata is shown in the third column, it'll push the width of the second column (the one displaying the raw byte values for each field) narrower. The result can be... a "less-than-ideal" UI:

![image](https://user-images.githubusercontent.com/1125786/85039100-aaa71780-b187-11ea-82ff-7750470238cd.png)

This change forces a `min-width` of `30em`, which *should* be just enough for displaying 16 bytes per row.