### PR TITLE
Wait longer before dying

### DIFF
--- a/tiffhax.go
+++ b/tiffhax.go
@@ -47,7 +47,7 @@ func setupHttpServer(data payload.Payload) net.Listener {
 
 		// Now that the page has been loaded the program can exit once we've given the http handler time to finish its stuff
 		go func() {
-			time.Sleep(10 *time.Millisecond)
+			time.Sleep(5000 *time.Millisecond)
 			os.Exit(0)
 		}()
 


### PR DESCRIPTION
This covers a case where running xdg-open doesn't launch a web browser
immediately, but an interim program to request the resource, check its
mimetype, then decice that, yes, a web browser should be launched; in
practice this means that the important request to wait for before dying
is the second one and not the first one.

In practice, waiting a few seconds more works just as fine.